### PR TITLE
Port to C5 + other changes

### DIFF
--- a/dbus.egg
+++ b/dbus.egg
@@ -1,0 +1,11 @@
+((synopsis "A binding for libdbus, the IPC mechanism")
+ (category os)
+ (license "MIT")
+ (author "Shawn Rutledge")
+ (maintainer "John J. Foerch")
+ (dependencies miscmacros srfi-18 foreigners)
+ (component-options (csc-options "-O3" "-d1" "-C" "`pkg-config --cflags dbus-1`")
+                    (link-options "-L" "`pkg-config --libs dbus-1`"))
+ (components
+  (extension dbus (source "dbus.scm")))
+ (version "0.95"))

--- a/dbus.scm
+++ b/dbus.scm
@@ -195,8 +195,6 @@
 
 (define default-signal-handler (make-parameter #f))
 
-(define (identity a) a)
-
 (define-foreign-type error-ptr (c-pointer "DBusError")
   identity
   (lambda (p)

--- a/dbus.scm
+++ b/dbus.scm
@@ -92,7 +92,7 @@
 (define-record-printer (object-path d out)
   (fprintf out "#<object-path ~s>" (object-path->string d)))
 
-(define auto-unbox-object-paths (make-parameter #f))
+(define auto-unbox-object-paths (make-parameter #t))
 
 
 ;; Scheme is a dynamically typed language, so fundamentally we don't
@@ -113,7 +113,7 @@
 ;; you want to send (marshall) a dbus message.  But probably
 ;; you want to turn it on for convenience, if you don't care to know
 ;; about this low-level detail.
-(define auto-unbox-variants (make-parameter #f))
+(define auto-unbox-variants (make-parameter #t))
 
 
 ;; A DBus struct is represented as a vector, but it's tagged for marshalling
@@ -137,7 +137,7 @@
 ;; By default this feature is turned off, in the interest of having a
 ;; representation that is the same as you will need to build when
 ;; you want to send (marshall) a dbus message.
-(define auto-unbox-structs (make-parameter #f))
+(define auto-unbox-structs (make-parameter #t))
 
 
 ;; Would want to do this:

--- a/dbus.scm
+++ b/dbus.scm
@@ -22,6 +22,7 @@
      default-signal-handler
      printing-signal-handler
      dump-callback-table
+     get-property
 
      make-variant
      variant?
@@ -954,4 +955,20 @@
     (let ((xml (call ctxt "Introspect")))
       (and (pair? xml) (car xml)))))
 
-) ;; end module
+(define (get-property context prop)
+  (let* ((bus (vector-ref context context-idx-bus))
+         (service (vector-ref context context-idx-service))
+         (path (vector-ref context context-idx-path))
+         (old-interface (vector-ref context context-idx-interface))
+         (context
+          (make-context
+           bus: bus
+           service: service
+           path: path
+           interface: 'org.freedesktop.DBus.Properties))
+         (raw
+          (handle-exceptions err #f
+            (call context "Get" (symbol?->string old-interface) (symbol?->string prop)))))
+    (and raw (car raw))))
+
+  ) ;; end module

--- a/dbus.scm
+++ b/dbus.scm
@@ -41,12 +41,27 @@
      object-path->string
      auto-unbox-object-paths)
 
-(import scheme chicken foreign)
+(import scheme)
 
-(use (srfi 18)
-     extras
-     foreigners
-     miscmacros)
+(cond-expand
+  (chicken-5
+   (import (chicken base)
+           (chicken foreign)
+           (chicken format)
+           (chicken gc)
+           (chicken condition)
+           (chicken pretty-print)
+           (srfi 18)
+           foreigners
+           miscmacros))
+  (else
+   (import chicken foreign)
+   (use (srfi 18)
+        extras
+        foreigners
+        miscmacros)))
+
+
 
 #>
 #include <dbus/dbus.h>


### PR DESCRIPTION
- Port dbus to C5 (with C4 backwards compatibility)
- Don't redefine identity (it's in chicken base already)
- Auto unbox by default (arguably more useful in regular scheme usage, may just be preference)
- Add `get-property` convenience function - it seems like a hassle to have to define a _whole other_ context just to call the method "Get" on the `org.freedesktop.Dbus.Properties` interface to get a property value, so provide an ease of use function for that.  It additionally handles the fairly vague "not a pointer" error when a property doesn't exist by just returning `#f`.